### PR TITLE
Data dump script

### DIFF
--- a/nuldc/dump.py
+++ b/nuldc/dump.py
@@ -10,15 +10,22 @@ API = "https://api.dc.library.northwestern.edu/api/v2"
 
 
 def slugify(s):
-  s = s.lower().strip()
-  s = re.sub(r'[^\w\s-]', '', s)
-  s = re.sub(r'[\s_-]+', '-', s)
-  s = re.sub(r'^-+|-+$', '', s)
-  return s
+    """takes a string and removes special characters, lowercases, and dashes it"""
+
+    s = s.lower().strip()
+    s = re.sub(r'[^\w\s-]', '', s)
+    s = re.sub(r'[\s_-]+', '-', s)
+    s = re.sub(r'^-+|-+$', '', s)
+    return s
 
 
 def save_files(basename, data):
     """takes a base filename and saves json, csv, and xml"""
+    
+    # make the directories if they don't exist
+    for d in ['json','xml','csv']:
+        if not os.path.isdir(d):
+            os.mkdir(d)
 
     with open(f"json/{basename}.json", 'w', encoding='utf-8') as f:
         json.dump(data.get('data'), f)
@@ -33,14 +40,14 @@ def dump_collection(col_id):
     """ Takes a collection id and grabs metadata then dumps into
     json, xml, and csv files"""
 
-        query = {"query":"collection.id:"+col_id}
-        data = helpers.get_search_results(API, 
-                                   "works", 
-                                   query, all_results=True)
+    query = {"query":f"collection.id:{col_id}"}
+    data = helpers.get_search_results(API, 
+                               "works", 
+                               query, all_results=True)
 
-        col_title = data['data'][0]['collection']['title']
-        filename = f"{slugify(col_title)}-{col_id}"
-        save_files(filename, data)
+    col_title = data['data'][0]['collection']['title']
+    filename = f"{slugify(col_title)}-{col_id}"
+    save_files(filename, data)
 
 
 def dump_collections(query_string):
@@ -67,17 +74,10 @@ def dump_collections(query_string):
 def main():
     """ Grabs all metadata. If there is an _updated_at.txt file it will only get 
     collections containign works updated since its modified date. """
-    
-    # make the directories if they don't exist
-    for d in ['json','xml','csv']:
-        if not os.path.isdir(d):
-            os.mkdir(d)
 
     if os.path.isfile("_updated_at.txt"):
         updated = os.path.getmtime('_updated_at.txt')
         query = f"modified_date:>={datetime.date.fromtimestamp(updated)}"
-
-        # query = f"modified_date:>=2022-10-01"
         print(f"looking for collections with works updated since {query}")
     else: 
         print("can't find updated since file, rebuilding all collections")

--- a/nuldc/dump.py
+++ b/nuldc/dump.py
@@ -1,6 +1,5 @@
 from nuldc import helpers
 import json
-
 import re
 
 def slugify(s):

--- a/nuldc/dump.py
+++ b/nuldc/dump.py
@@ -1,0 +1,46 @@
+from nuldc import helpers
+import json
+
+import re
+
+def slugify(s):
+  s = s.lower().strip()
+  s = re.sub(r'[^\w\s-]', '', s)
+  s = re.sub(r'[\s_-]+', '-', s)
+  s = re.sub(r'^-+|-+$', '', s)
+  return s
+
+def save_files(basename, data):
+    """takes a base filename and saves json, csv, and xml"""
+
+    with open(f"json/{basename}.json", 'w', encoding='utf-8') as f:
+        json.dump(data.get('data'), f)
+
+    helpers.save_xml(data.get('data'), f'xml/{basename}.xml')
+
+    headers, values  = helpers.sort_fields_and_values(data) 
+
+    helpers.save_as_csv(headers, values, f'csv/{basename}.csv')
+
+
+def dump_collections():
+    """This dumps collections from a collectionlist. TODO agg on collection
+    so  that a search could include --since and only return collections 
+    changed"""
+
+    api = "https://api.dc.library.northwestern.edu/api/v2"
+
+    collections = helpers.get_search_results(api, 
+                                             "collections", 
+                                             {"query":"*", "size":1000}, 
+                                             page_limit=1000)
+ 
+    for col in collections.get('data'):
+        identifier = col.get('id')
+        title = col.get('title')
+        query = {"query":"collection.id:"+identifier}
+        data = helpers.get_search_results(api, 
+                                   "works", 
+                                   query, all_results=False)
+        filename = f"{slugify(col['title'])}-{col['id']}"
+        save_files(filename, data)

--- a/nuldc/dump.py
+++ b/nuldc/dump.py
@@ -1,6 +1,13 @@
 from nuldc import helpers
 import json
 import re
+import concurrent.futures
+import datetime
+import os
+
+
+API = "https://api.dc.library.northwestern.edu/api/v2" 
+
 
 def slugify(s):
   s = s.lower().strip()
@@ -8,6 +15,7 @@ def slugify(s):
   s = re.sub(r'[\s_-]+', '-', s)
   s = re.sub(r'^-+|-+$', '', s)
   return s
+
 
 def save_files(basename, data):
     """takes a base filename and saves json, csv, and xml"""
@@ -18,28 +26,61 @@ def save_files(basename, data):
     helpers.save_xml(data.get('data'), f'xml/{basename}.xml')
 
     headers, values  = helpers.sort_fields_and_values(data) 
-
     helpers.save_as_csv(headers, values, f'csv/{basename}.csv')
 
 
-def dump_collections():
-    """This dumps collections from a collectionlist. TODO agg on collection
-    so  that a search could include --since and only return collections 
-    changed"""
+def dump_collection(col_id):
+    """ Takes a collection id and grabs metadata then dumps into
+    json, xml, and csv files"""
 
-    api = "https://api.dc.library.northwestern.edu/api/v2"
-
-    collections = helpers.get_search_results(api, 
-                                             "collections", 
-                                             {"query":"*", "size":1000}, 
-                                             page_limit=1000)
- 
-    for col in collections.get('data'):
-        identifier = col.get('id')
-        title = col.get('title')
-        query = {"query":"collection.id:"+identifier}
-        data = helpers.get_search_results(api, 
+        query = {"query":"collection.id:"+col_id}
+        data = helpers.get_search_results(API, 
                                    "works", 
-                                   query, all_results=False)
-        filename = f"{slugify(col['title'])}-{col['id']}"
+                                   query, all_results=True)
+
+        col_title = data['data'][0]['collection']['title']
+        filename = f"{slugify(col_title)}-{col_id}"
         save_files(filename, data)
+
+
+def dump_collections(query_string):
+    """This dumps collections from a collectionlist.""" 
+    
+    search_url = f'{API}/search' 
+    # get collections list 
+    collections = helpers.aggregate_by(search_url, 
+                                       query_string, 
+                                       "collection.id", 
+                                       1000) 
+    # grab data for each collection and dump
+    collections = collections.json()['aggregations']['collection.id']['buckets']
+
+    collection_ids = [c.get('key') for c in collections]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        executor.map(dump_collection, collection_ids)
+
+    with open('_updated_at.txt', 'w') as f:
+        f.write(f'updated {datetime.datetime.now()}')
+
+
+def main():
+    """ Grabs all metadata. If there is an _updated_at.txt file it will only get 
+    collections containign works updated since its modified date. """
+    
+    # make the directories if they don't exist
+    for d in ['json','xml','csv']:
+        if not os.path.isdir(d):
+            os.mkdir(d)
+
+    if os.path.isfile("_updated_at.txt"):
+        updated = os.path.getmtime('_updated_at.txt')
+        query = f"modified_date:>={datetime.date.fromtimestamp(updated)}"
+
+        # query = f"modified_date:>=2022-10-01"
+        print(f"looking for collections with works updated since {query}")
+    else: 
+        print("can't find updated since file, rebuilding all collections")
+        query = "*"
+
+    dump_collections(query)

--- a/nuldc/helpers.py
+++ b/nuldc/helpers.py
@@ -191,7 +191,25 @@ def sort_fields_and_values(opensearch_results, fields=[]):
     return fields, values
 
 
-def aggregate_by(search_url, query, agg):
+def aggregate_by(search_url, query_string, agg, size):
     """ Takes a base url and a query string query and aggs on a single
     agg field"""
-    pass
+
+    query = {
+              "size": "0",
+              "query": {
+                "query_string": {
+                  "query": query_string
+                  }
+              },
+            "aggs": {
+                agg: {
+                  "terms": {
+                    "field": agg,
+                    "size": size
+                  }
+                }
+              }
+            }
+
+    return requests.post(search_url, json=query)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dicttoxml = "^1.7.16"
 
 [tool.poetry.scripts]
 nuldc = 'nuldc.commandline:main'
-
+nuldump = 'nuldc.dump:main'
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This adds a script that takes a snapshot of metadata in the api, organizing it by format and collection.

It can be tested by installing the nuldc cli and running `nuldump` in a clean directory. The command will aggressively hit the api and pull all the metadata from all collections. 

After a successful run an `_updated_at.txt` will be present in the directory alongside a `json`, `xml`, and `csv` directories. A rerun of nuldump in the directory will only update collections updated since the `_updated_at.txt` file was modified. To test this functionality, manually update the modified date with `touch -d 2022-01-01T00:00:00 _updated_at.txt` . 

The end goal will be to have a github action run the nuldump command at some interval. 